### PR TITLE
Corrected issue with java params

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -14,7 +14,9 @@ class druid (
   $mysql_user             = 'root',       # druid.db.connector.user
   $mysql_pass             = '',           # druid.db.connector.password
   $use_validation_query   = 'true',       # druid.db.connector.useValidationQuery
+  $jvm_thread_stack_size  = '512m',       # -Xss
   $jvm_heap_max           = '256m',       # -Xmx
+  $jvm_max_perm_size      = '64m',        # -XX:MaxPermSize
 
   $storage_type           = 's3',         # druid.storage.type
   $storage_bucket         = '',           # druid.storage.bucket

--- a/manifests/node/broker.pp
+++ b/manifests/node/broker.pp
@@ -51,7 +51,7 @@ class druid::node::broker (
   supervisor::program { 'druid-broker':
     ensure      => present,
     enable      => true,
-    command     => "/usr/bin/java -Xmx$jvm_heap_max -Duser.timezone=$timezone -Dfile.encoding=$encoding -classpath '${druid::druid_dir}/current/*:/etc/druid/broker' io.druid.cli.Main server broker",
+    command     => "/usr/bin/java -Xss$jvm_thread_stack_size -Xmx$jvm_heap_max  -XX:MaxPermSize=$jvm_max_perm_size -Duser.timezone=$timezone -Dfile.encoding=$encoding -classpath '${druid::druid_dir}/current/*:/etc/druid/broker' io.druid.cli.Main server broker",
     directory   => $druid::druid_dir,
     user        => 'druid',
     group       => 'druid',

--- a/manifests/node/broker.pp
+++ b/manifests/node/broker.pp
@@ -51,7 +51,7 @@ class druid::node::broker (
   supervisor::program { 'druid-broker':
     ensure      => present,
     enable      => true,
-    command     => "/usr/bin/java -classpath '${druid::druid_dir}/current/*:/etc/druid/broker' io.druid.cli.Main server broker",
+    command     => "/usr/bin/java -Xmx$jvm_heap_max -Duser.timezone=$timezone -Dfile.encoding=$encoding -classpath '${druid::druid_dir}/current/*:/etc/druid/broker' io.druid.cli.Main server broker",
     directory   => $druid::druid_dir,
     user        => 'druid',
     group       => 'druid',

--- a/manifests/node/coordinator.pp
+++ b/manifests/node/coordinator.pp
@@ -61,7 +61,7 @@ class druid::node::coordinator (
   supervisor::program { 'druid-coordinator':
     ensure      => present,
     enable      => true,
-    command     => "/usr/bin/java -classpath '${druid::druid_dir}/current/*:/etc/druid/coordinator' io.druid.cli.Main server coordinator",
+    command     => "/usr/bin/java -Xmx$jvm_heap_max -Duser.timezone=$timezone -Dfile.encoding=$encoding -classpath '${druid::druid_dir}/current/*:/etc/druid/coordinator' io.druid.cli.Main server coordinator",
     directory   => $druid::druid_dir,
     user        => 'druid',
     group       => 'druid',

--- a/manifests/node/coordinator.pp
+++ b/manifests/node/coordinator.pp
@@ -61,7 +61,7 @@ class druid::node::coordinator (
   supervisor::program { 'druid-coordinator':
     ensure      => present,
     enable      => true,
-    command     => "/usr/bin/java -Xmx$jvm_heap_max -Duser.timezone=$timezone -Dfile.encoding=$encoding -classpath '${druid::druid_dir}/current/*:/etc/druid/coordinator' io.druid.cli.Main server coordinator",
+    command     => "/usr/bin/java -Xss$jvm_thread_stack_size -Xmx$jvm_heap_max  -XX:MaxPermSize=$jvm_max_perm_size -Duser.timezone=$timezone -Dfile.encoding=$encoding -classpath '${druid::druid_dir}/current/*:/etc/druid/coordinator' io.druid.cli.Main server coordinator",
     directory   => $druid::druid_dir,
     user        => 'druid',
     group       => 'druid',

--- a/manifests/node/historical.pp
+++ b/manifests/node/historical.pp
@@ -68,7 +68,7 @@ class druid::node::historical (
   supervisor::program { 'druid-historical':
     ensure      => present,
     enable      => true,
-    command     => "/usr/bin/java -Xmx$jvm_heap_max -Duser.timezone=$timezone -Dfile.encoding=$encoding -classpath '${druid::druid_dir}/current/*:/etc/druid/historical' io.druid.cli.Main server historical",
+    command     => "/usr/bin/java -Xss$jvm_thread_stack_size -Xmx$jvm_heap_max  -XX:MaxPermSize=$jvm_max_perm_size -Duser.timezone=$timezone -Dfile.encoding=$encoding -classpath '${druid::druid_dir}/current/*:/etc/druid/historical' io.druid.cli.Main server historical",
     directory   => $druid::druid_dir,
     user        => 'druid',
     group       => 'druid',

--- a/manifests/node/historical.pp
+++ b/manifests/node/historical.pp
@@ -68,7 +68,7 @@ class druid::node::historical (
   supervisor::program { 'druid-historical':
     ensure      => present,
     enable      => true,
-    command     => "/usr/bin/java -classpath '${druid::druid_dir}/current/*:/etc/druid/historical' io.druid.cli.Main server historical",
+    command     => "/usr/bin/java -Xmx$jvm_heap_max -Duser.timezone=$timezone -Dfile.encoding=$encoding -classpath '${druid::druid_dir}/current/*:/etc/druid/historical' io.druid.cli.Main server historical",
     directory   => $druid::druid_dir,
     user        => 'druid',
     group       => 'druid',

--- a/manifests/node/overlord.pp
+++ b/manifests/node/overlord.pp
@@ -59,7 +59,7 @@ class druid::node::overlord (
   supervisor::program { 'druid-overlord':
     ensure      => present,
     enable      => true,
-    command     => "/usr/bin/java -classpath '${druid::druid_dir}/current/*:/etc/druid/overlord' io.druid.cli.Main server overlord",
+    command     => "/usr/bin/java -Xmx$jvm_heap_max -Duser.timezone=$timezone -Dfile.encoding=$encoding -classpath '${druid::druid_dir}/current/*:/etc/druid/overlord' io.druid.cli.Main server overlord",
     directory   => $druid::druid_dir,
     user        => 'druid',
     group       => 'druid',

--- a/manifests/node/overlord.pp
+++ b/manifests/node/overlord.pp
@@ -59,7 +59,7 @@ class druid::node::overlord (
   supervisor::program { 'druid-overlord':
     ensure      => present,
     enable      => true,
-    command     => "/usr/bin/java -Xmx$jvm_heap_max -Duser.timezone=$timezone -Dfile.encoding=$encoding -classpath '${druid::druid_dir}/current/*:/etc/druid/overlord' io.druid.cli.Main server overlord",
+    command     => "/usr/bin/java -Xss$jvm_thread_stack_size -Xmx$jvm_heap_max  -XX:MaxPermSize=$jvm_max_perm_size -Duser.timezone=$timezone -Dfile.encoding=$encoding -classpath '${druid::druid_dir}/current/*:/etc/druid/overlord' io.druid.cli.Main server overlord",
     directory   => $druid::druid_dir,
     user        => 'druid',
     group       => 'druid',

--- a/manifests/node/realtime.pp
+++ b/manifests/node/realtime.pp
@@ -80,7 +80,7 @@ class druid::node::realtime (
   supervisor::program { 'druid-realtime':
     ensure      => present,
     enable      => true,
-    command     => "/usr/bin/java -Xmx$jvm_heap_max -Duser.timezone=$timezone -Dfile.encoding=$encoding -classpath '${druid::druid_dir}/current/*:/etc/druid/realtime' io.druid.cli.Main server realtime",
+    command     => "/usr/bin/java -Xss$jvm_thread_stack_size -Xmx$jvm_heap_max  -XX:MaxPermSize=$jvm_max_perm_size -Duser.timezone=$timezone -Dfile.encoding=$encoding -classpath '${druid::druid_dir}/current/*:/etc/druid/realtime' io.druid.cli.Main server realtime",
     directory   => $druid::druid_dir,
     user        => 'druid',
     group       => 'druid',

--- a/manifests/node/realtime.pp
+++ b/manifests/node/realtime.pp
@@ -80,7 +80,7 @@ class druid::node::realtime (
   supervisor::program { 'druid-realtime':
     ensure      => present,
     enable      => true,
-    command     => "/usr/bin/java -classpath '${druid::druid_dir}/current/*:/etc/druid/realtime' io.druid.cli.Main server realtime",
+    command     => "/usr/bin/java -Xmx$jvm_heap_max -Duser.timezone=$timezone -Dfile.encoding=$encoding -classpath '${druid::druid_dir}/current/*:/etc/druid/realtime' io.druid.cli.Main server realtime",
     directory   => $druid::druid_dir,
     user        => 'druid',
     group       => 'druid',

--- a/templates/node/head.runtime.properties.erb
+++ b/templates/node/head.runtime.properties.erb
@@ -2,10 +2,6 @@
 # this file is managed by puppet
 # please do not change
 #
--server
--Xmx<%= @jvm_heap_max %>
--Duser.timezone=<%= @timezone %>
--Dfile.encoding=<%= @encoding %>
 druid.host=<%= @listen %>
 druid.port=<%= @port %>
 druid.zk.service.host=<%= @zk_host %>


### PR DESCRIPTION
See (https://github.com/jowy/puppet-druid/issues/2)

Java params are now correctly passed to supervisord : 
- Xmx$jvm_heap_max 
- Duser.timezone=$timezone 
- Dfile.encoding=$encoding

2 new params could be used : 
- jvm_thread_stack_size (-Xss)
- jvm_max_perm_size (-XX:MaxPermSize)